### PR TITLE
NSA-303 Add ability to request fields on the get

### DIFF
--- a/src/app/digipass/checkDeviceExists.js
+++ b/src/app/digipass/checkDeviceExists.js
@@ -2,7 +2,19 @@ const { getDigipassDetails } = require('./../../infrastructure/deviceStorage');
 
 const checkDeviceExists = async (req, res) => {
   const deviceDetails = await getDigipassDetails(req.params.serial_number, req.header('x-correlation-id'));
-  res.status(deviceDetails ? 204 : 404).send();
+  let filterdFields = {};
+  if (deviceDetails && req.query.fields) {
+    const fields = req.query.fields.split(',');
+    filterdFields = Object.keys(deviceDetails)
+      .filter(key => fields.includes(key))
+      .reduce((obj, key) => {
+        obj[key] = deviceDetails[key];
+        return obj;
+      }, {});
+    return res.send(filterdFields);
+  }
+
+  return res.status(deviceDetails ? 204 : 404).send();
 };
 
 module.exports = checkDeviceExists;

--- a/test/appTests/digipassTests/checkDeviceExists.test.js
+++ b/test/appTests/digipassTests/checkDeviceExists.test.js
@@ -18,6 +18,8 @@ describe('when checking if a digipass exists with a serial number', () => {
       params: {
         serial_number: '112345671',
       },
+      query: {
+      },
     };
 
     res = httpMocks.createResponse();
@@ -28,9 +30,12 @@ describe('when checking if a digipass exists with a serial number', () => {
       counterPosition: 0,
       secret: 'some-secret',
       codeLength: 8,
+      unlock1: '123456',
     });
   });
-
+  afterEach(() => {
+    expect(res._isEndCalled()).toBe(true);
+  });
   it('then it should get device details using serial number from params', async () => {
     await checkDeviceExists(req, res);
 
@@ -43,7 +48,6 @@ describe('when checking if a digipass exists with a serial number', () => {
     await checkDeviceExists(req, res);
 
     expect(res.statusCode).toBe(204);
-    expect(res._isEndCalled()).toBe(true);
   });
 
   it('then it should return 404 if device not found', async () => {
@@ -52,6 +56,14 @@ describe('when checking if a digipass exists with a serial number', () => {
     await checkDeviceExists(req, res);
 
     expect(res.statusCode).toBe(404);
-    expect(res._isEndCalled()).toBe(true);
+  });
+
+  it('then the fields will be filtered if the query string is populated and the values returned in the response', async () => {
+    req.query.fields = 'unlock1';
+
+    await checkDeviceExists(req, res);
+
+    expect(res._getData().unlock1).toBe('123456');
+    expect(res._getData().serialNumber).toBe(undefined);
   });
 });


### PR DESCRIPTION
When getting an individual token by serial number, you can request on the query string the fields that you want to be returned in the response